### PR TITLE
Win32 implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,46 @@ if(RESOURCE_PATH)
 	message(STATUS "Default resource path : ${RESOURCE_PATH}") 
 endif()
 
+# Windows things
+if(WIN32)
+  include(FetchContent)
+
+  FetchContent_Declare(
+    glm
+    GIT_REPOSITORY	https://github.com/g-truc/glm.git
+    # GIT_TAG bf71a834948186f4097caa076cd2663c69a10e1e #refs/tags/1.0.1
+  )
+
+  FetchContent_MakeAvailable(glm)
+
+  FetchContent_Declare(
+    yaml-cpp
+    GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
+    # GIT_TAG f7320141120f720aecc4c32be25586e7da9eb978 # Can be a tag (yaml-cpp-x.x.x), a commit hash, or a branch name (master)
+  )
+
+  FetchContent_MakeAvailable(yaml-cpp)
+
+  FetchContent_Declare(
+    glfw3
+    GIT_REPOSITORY https://github.com/glfw/glfw.git
+    # GIT_TAG 3.4
+  )
+
+  # Avoid building extras
+  set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+  set(GLFW_BUILD_TESTS    OFF CACHE BOOL "" FORCE)
+  set(GLFW_BUILD_DOCS     OFF CACHE BOOL "" FORCE)
+
+  FetchContent_MakeAvailable(glfw3) 
+else()
+  find_package(glm CONFIG REQUIRED)
+  find_package(yaml-cpp REQUIRED)
+  find_package(glfw3 REQUIRED)
+endif()
+
 find_package(OpenGL REQUIRED)
-find_package(glm CONFIG REQUIRED)
-find_package(yaml-cpp REQUIRED)
-find_package(glfw3 REQUIRED)
+
 
 add_compile_options(-g)
 

--- a/deps/imgui/CMakeLists.txt
+++ b/deps/imgui/CMakeLists.txt
@@ -13,4 +13,5 @@ file(GLOB SOURCES
 
 add_library(imgui STATIC ${SOURCES})
 
+target_link_libraries(imgui PUBLIC glfw)
 target_include_directories(imgui PUBLIC imgui implot)

--- a/deps/imgui/CMakeLists.txt
+++ b/deps/imgui/CMakeLists.txt
@@ -13,5 +13,8 @@ file(GLOB SOURCES
 
 add_library(imgui STATIC ${SOURCES})
 
-target_link_libraries(imgui PUBLIC glfw)
+if(WIN32)
+    target_link_libraries(imgui PUBLIC glfw)
+endif()
+
 target_include_directories(imgui PUBLIC imgui implot)

--- a/engine/include/engine/globe/tiling.h
+++ b/engine/include/engine/globe/tiling.h
@@ -107,7 +107,7 @@ static inline uint8_t cube_face(glm::dvec3 v)
 
 template<typename T>
 static inline glm::vec<3, T, glm::defaultp> 
-world_to_face(glm::vec<3, T, glm::defaultp> v, uint face)
+world_to_face(glm::vec<3, T, glm::defaultp> v, unsigned int face)
 {
 	using _ty = glm::vec<3, T, glm::defaultp>;
 
@@ -123,7 +123,7 @@ world_to_face(glm::vec<3, T, glm::defaultp> v, uint face)
 }
 template<typename T>
 static inline glm::vec<3, T, glm::defaultp> 
-face_to_world(glm::vec<3, T, glm::defaultp> v, uint face)
+face_to_world(glm::vec<3, T, glm::defaultp> v, unsigned int face)
 {
 	using _ty = glm::vec<3, T, glm::defaultp>;
 

--- a/engine/src/globe/globe.cpp
+++ b/engine/src/globe/globe.cpp
@@ -385,6 +385,7 @@ struct alignas(16) TileMetadata
 {
 	glm::vec4 coord;
 	TileGPUIndex tex_idx;
+	
 };
 
 static LoadResult create_render_data(ResourceTable *rt, RenderData &data)

--- a/engine/src/globe/gpu_cache.cpp
+++ b/engine/src/globe/gpu_cache.cpp
@@ -442,6 +442,9 @@ void TileGPUCache::bind_texture_arrays(uint32_t base) const
 	assert(m_pages.size() <= MAX_TILE_PAGES);
 
 	for (size_t i = 0; i < m_pages.size(); ++i) {
+		if (!m_pages[i]->tex_array) {
+			log_error("Globe texture array %d has id 0!", i);
+		}
 		glActiveTexture(GL_TEXTURE0 + (GLenum)(base + i));
 		glBindTexture(GL_TEXTURE_2D_ARRAY, m_pages[i]->tex_array);	
 	}

--- a/samples/globe/main.cpp
+++ b/samples/globe/main.cpp
@@ -93,8 +93,10 @@ int main(int argc, char* argv[])
 	}
 #endif
 
-	if (!glfwInit())
+	if (!glfwInit()) {
+		log_error("Failed to initialize GLFW!");
 		return EXIT_FAILURE;
+	}
 	
 	struct {
 		struct{
@@ -137,6 +139,8 @@ int main(int argc, char* argv[])
 	    glfwTerminate();
 		return EXIT_FAILURE;
 	}
+
+	log_info("Window created");
 
 	g_window = window;
 

--- a/samples/globe/main.cpp
+++ b/samples/globe/main.cpp
@@ -140,8 +140,6 @@ int main(int argc, char* argv[])
 		return EXIT_FAILURE;
 	}
 
-	log_info("Window created");
-
 	g_window = window;
 
 	glfwGetFramebufferSize(window, &params.win.width, &params.win.height);

--- a/samples/src/app.cpp
+++ b/samples/src/app.cpp
@@ -157,7 +157,7 @@ int glfw_init_gl_basic(GLFWwindow *window)
 							  const GLchar* message,
 							  const void* userParam )
 	{
-		//if (severity == GL_DEBUG_SEVERITY_HIGH) {				
+		if (severity != GL_DEBUG_SEVERITY_NOTIFICATION) {				
 			fprintf(stderr,
 				"GL DEBUG: [%u] %s\n"
 				"    Source:   0x%x\n"
@@ -166,7 +166,7 @@ int glfw_init_gl_basic(GLFWwindow *window)
 				"    Message:  %s\n\n",
 				id, (type == GL_DEBUG_TYPE_ERROR ? "** ERROR **" : ""),
 				source, type, severity, message);
-		//}
+		}
 
 	}, nullptr);
 


### PR DESCRIPTION
Mostly fixes with CMake files using FetchContent with glfw, yaml-cpp. Windows must install binaries for `glslangValidator` and point PATH to them in order to compile shaders.